### PR TITLE
#! initial coordinates of centroid chosen more carefully

### DIFF
--- a/lib/k_means/centroid.rb
+++ b/lib/k_means/centroid.rb
@@ -1,6 +1,9 @@
 class Centroid
   
   class << self
+  
+    # initial centroid positions are randomly chosen from within
+    # a bounding box that encloses all the nodes
     def create_centroids(amount, nodes)
       ranges = create_ranges(nodes, nodes[0].position.size)
       (1..amount).map do
@@ -13,14 +16,15 @@ class Centroid
     
     private
     
+    # find centroid ranges as a bounding box for all nodes
     def create_ranges(nodes, dimensions)
-      ranges = Array.new(dimensions) {[0.0, 0.0]}
+      ranges = Array.new(dimensions) {[Float::NAN, Float::NAN]}
       nodes.each do |node|
         node.position.each_with_index do |position, index|
           # Bottom range
-          ranges[index][0] = position if position < ranges[index][0]
+          ranges[index][0] = position if ranges[index][0].nan? || position < ranges[index][0]
           # Top range
-          ranges[index][1] = position if position > ranges[index][1]
+          ranges[index][1] = position if ranges[index][1].nan? || position > ranges[index][1]
         end
       end
       ranges


### PR DESCRIPTION
In the previous version initial position of a centroid was always randomly chosen between 
`[0 - X, 0 - Y]`, that didn't work very well for situations where all points having larger coordinates like:

`[[1000,800], [1002, 900], [2000, 2500], [2200, 2000]]`

In this case initial centroids could be chosen as `[0, 0]` and `[1500, 1500]` which lead to clustering to one cluster only which is obviously wrong.